### PR TITLE
add configurable i18n dropdown

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,13 +1,13 @@
 <header class="site-header">
 
-  <div class="wrapper">
+  <div class="wrapper" style="max-width: calc(1200px - (30px * 2)); display: flex; justify-content: space-between;">
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
     {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
-    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    <a class="site-title" rel="author" style="float: none;" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 
     {%- if titles_size > 0 -%}
-      <nav class="site-nav">
+      <nav class="site-nav" style="float: none;">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />
         <label for="nav-trigger">
           <span class="menu-icon">
@@ -27,5 +27,8 @@
         </div>
       </nav>
     {%- endif -%}
+
+    {%- include i18n-dropdown.html -%}
+
   </div>
 </header>

--- a/_includes/i18n-dropdown.html
+++ b/_includes/i18n-dropdown.html
@@ -1,0 +1,37 @@
+<!-- Very very very basic i18n dropdown for mvp -->
+
+<style>
+  #i18n-dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  #i18n-dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #e7e7e7;
+    min-width: 160px;
+    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+    padding: 12px 16px;
+    z-index: 1;
+  }
+
+  #i18n-dropdown:hover #i18n-dropdown-content {
+    display: block;
+  }
+
+  #i18n-dropdown-button {
+    border: #e7e7e7 3px;
+    cursor: pointer;
+  }
+</style>
+
+<div id="i18n-dropdown">
+  <button id="i18n-dropdown-button">Language 🌐</button>
+  <div id="i18n-dropdown-content">
+    <a href="/">English</a>
+    {% for language in site.languages %}
+      <a href="/index.{{ language.code }}">{{ language.name | escape }}</a>
+    {% endfor %}
+  </div>
+</div>

--- a/_includes/i18n-dropdown.html
+++ b/_includes/i18n-dropdown.html
@@ -1,18 +1,6 @@
 <!-- Very very very basic i18n dropdown for mvp -->
 
 <style>
-  #i18n-dropdown,
-  #i18n-dropdown-content,
-  #i18n-dropdown-button {
-    background-color: #e7e7e7;
-    padding: 12px 16px;
-  }
-
-  #i18n-dropdown-button {
-    border: #e7e7e7 3px;
-    cursor: pointer;
-  }
-
   #i18n-dropdown {
     position: relative;
     display: inline-block;
@@ -21,12 +9,20 @@
   #i18n-dropdown-content {
     display: none;
     position: absolute;
+    background-color: #e7e7e7;
     min-width: 160px;
+    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
+    padding: 12px 16px;
     z-index: 1;
   }
 
   #i18n-dropdown:hover #i18n-dropdown-content {
     display: block;
+  }
+
+  #i18n-dropdown-button {
+    border: #e7e7e7 3px;
+    cursor: pointer;
   }
 </style>
 

--- a/_includes/i18n-dropdown.html
+++ b/_includes/i18n-dropdown.html
@@ -1,6 +1,18 @@
 <!-- Very very very basic i18n dropdown for mvp -->
 
 <style>
+  #i18n-dropdown,
+  #i18n-dropdown-content,
+  #i18n-dropdown-button {
+    background-color: #e7e7e7;
+    padding: 12px 16px;
+  }
+
+  #i18n-dropdown-button {
+    border: #e7e7e7 3px;
+    cursor: pointer;
+  }
+
   #i18n-dropdown {
     position: relative;
     display: inline-block;
@@ -9,29 +21,23 @@
   #i18n-dropdown-content {
     display: none;
     position: absolute;
-    background-color: #e7e7e7;
     min-width: 160px;
-    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
-    padding: 12px 16px;
     z-index: 1;
   }
 
   #i18n-dropdown:hover #i18n-dropdown-content {
     display: block;
   }
-
-  #i18n-dropdown-button {
-    border: #e7e7e7 3px;
-    cursor: pointer;
-  }
 </style>
 
 <div id="i18n-dropdown">
   <button id="i18n-dropdown-button">Language 🌐</button>
   <div id="i18n-dropdown-content">
-    <a href="/">English</a>
-    {% for language in site.languages %}
-      <a href="/index.{{ language.code }}">{{ language.name | escape }}</a>
-    {% endfor %}
+    <ul style="list-style: none;">
+      <li><a href="/">English</a></li>
+      {% for language in site.languages %}
+      <li><a href="/index.{{ language.code }}">{{ language.name | escape }}</a></li>
+      {% endfor %}
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
hey, so heres the very basic stuff for the i18n

it works, i didnt go any further than that in terms of design or whatnot ill leave that up to far better people than me :sweat_smile: 

you just need to merge this

then we can edit the config file on the main repo (rms-open-letter /rms-open-letter.github.io) and simply add the languages in new PR
```
remote_theme: XXXXXX/minima
languages:
  - name: "French"
    code: "fr"
  - name: "Spanish"
    code: "es"
  - name: "Turkish"
    code: "tr"

```

i have a demo setup running on my fork to see what it looks like (bad), but it works **except i dont have a base level domain for my github pages like yours, its a /blabla so links dont work in demo but they will on the main repo**
https://jukefr.github.io/rms-open-letter.github.io/
https://github.com/jukefr/rms-open-letter.github.io

**also VERY IMPORTANT** i am not a frontend, i'm a backend :sweat_smile: so I am not at all up to page with how to make this a11y, for people that interact in different manners with the web, so I hope somebody can look into that and make a PR, it might be a good idea to link the issue also on the main repo so that people pick it up**