### PR TITLE
Mobile Overflow

### DIFF
--- a/assets/scripts/a11y-menu.js
+++ b/assets/scripts/a11y-menu.js
@@ -358,7 +358,7 @@ PopupMenuLinks.prototype.open = function () {
   this.domNode.style.display = "block";
   this.domNode.style.position = "absolute";
   this.domNode.style.top = rect.height + "px";
-  this.domNode.style.left = "0px";
+  this.domNode.style.right = "0px";
 
   // set aria-expanded attribute
   this.controller.domNode.setAttribute("aria-expanded", "true");


### PR DESCRIPTION
Currently the i18n dropdown causes overflow-x on smaller devices.
This PR changes `left: 0px` to `right: 0px`.

Before:
![Screenshot showing the dropdown overflow on mobile](https://user-images.githubusercontent.com/18014039/112655605-7a905180-8e48-11eb-839c-2a6ab779e766.png)

After:
![Screenshot showing the dropdown with the new change on mobile](https://user-images.githubusercontent.com/18014039/112655699-9267d580-8e48-11eb-8e9f-d0408600612e.png)
