### PR TITLE
Add direction control for i18n

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{%- assign rtl_langs = "ar, arc, dv, fa, ha, he, khw, ks, ku, ps, ur, yi" | split: ", " -%}
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
   {%- include head.html -%}
@@ -9,7 +10,7 @@
 
     <main class="page-content" aria-label="Content">
       <div class="wrapper"
-        {% if page.dir %} dir="{{ page.dir }}" {% endif %}>
+        {%- if rtl_langs contains page.lang -%} dir="rtl" {%- endif -%}>
         {{ content }}
       </div>
     </main>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,8 @@
     {%- include header.html -%}
 
     <main class="page-content" aria-label="Content">
-      <div class="wrapper">
+      <div class="wrapper"
+        {% if page.dir %} dir="{{ page.dir }}" {% endif %}>
         {{ content }}
       </div>
     </main>


### PR DESCRIPTION
Currently the farsi and arabic pages are full of explicit directions.

Doesn't need to be like that.

(I will also get a PR out to actually use these things. That one would depend on this one for obvious reasons.)